### PR TITLE
Allow numpy 1.12 as minimum version for Python < 3.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: dff246a3fa03fe5c815f290825345a6ad5ff49df5e1882f123e632a4217bbcd1
 
 build:
-  number: 0
+  number: 1
   skip: true  # solvers are missing on:  # [win]
 
 # Need these up here for conda-smithy to handle them properly.
@@ -52,7 +52,8 @@ outputs:
         - {{ compiler('cxx') }}
       host:
         - python
-        - numpy 1.14
+        - numpy 1.14.*  # [py==37]
+        - numpy 1.12.*  # [py!=37]
         - pip
       run:
         - python


### PR DESCRIPTION
Currently, cvxpy can only be installed with numpy 1.14 or later, which is not required for cvxpy to work. The minimum numpy version is set to 1.12 for Python < 3.7. This has been adapted from the [pandas feedstock](https://github.com/conda-forge/pandas-feedstock/blob/master/recipe/meta.yaml).