### PR TITLE
adopt upstream recipe test imports

### DIFF
--- a/.ci_support/linux_aarch64_numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.16python3.6.____cpython.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '7.5'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '7.5'
 docker_image:
 - condaforge/linux-anvil-aarch64
 numpy:

--- a/.ci_support/linux_aarch64_numpy1.16python3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.16python3.7.____cpython.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '7.5'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '7.5'
 docker_image:
 - condaforge/linux-anvil-aarch64
 numpy:

--- a/.ci_support/linux_aarch64_numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.16python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '7.5'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '7.5'
 docker_image:
 - condaforge/linux-anvil-aarch64
 numpy:

--- a/.ci_support/linux_aarch64_numpy1.18python3.6.____73_pypy.yaml
+++ b/.ci_support/linux_aarch64_numpy1.18python3.6.____73_pypy.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '7.5'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '7.5'
 docker_image:
 - condaforge/linux-anvil-aarch64
 numpy:

--- a/.ci_support/osx_64_numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.16python3.6.____cpython.yaml
@@ -14,8 +14,6 @@ cxx_compiler_version:
 - '10'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 numpy:
 - '1.16'
 pin_run_as_build:

--- a/.ci_support/osx_64_numpy1.16python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.16python3.7.____cpython.yaml
@@ -14,8 +14,6 @@ cxx_compiler_version:
 - '10'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 numpy:
 - '1.16'
 pin_run_as_build:

--- a/.ci_support/osx_64_numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.16python3.8.____cpython.yaml
@@ -14,8 +14,6 @@ cxx_compiler_version:
 - '10'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 numpy:
 - '1.16'
 pin_run_as_build:

--- a/.ci_support/osx_64_numpy1.18python3.6.____73_pypy.yaml
+++ b/.ci_support/osx_64_numpy1.18python3.6.____73_pypy.yaml
@@ -14,8 +14,6 @@ cxx_compiler_version:
 - '10'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 numpy:
 - '1.18'
 pin_run_as_build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,7 +63,6 @@ outputs:
         - python
         - {{ pin_compatible('numpy') }}
         - scipy >=1.1.0
-        - multiprocess
     test:
       imports:
         - cvxpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,7 +64,6 @@ outputs:
         - {{ pin_compatible('numpy') }}
         - scipy >=1.1.0
         - multiprocess
-        - six
     test:
       imports:
         - cvxpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,6 +46,7 @@ outputs:
         - nose
       commands:
         - nosetests cvxpy
+
   - name: cvxpy-base
     build:
       script: {{ PYTHON }} -m pip install . --no-deps -vvv
@@ -67,7 +68,35 @@ outputs:
     test:
       imports:
         - cvxpy
+        - cvxpy.atoms
+        - cvxpy.atoms.affine
+        - cvxpy.atoms.elementwise
         - cvxpy.cvxcore
+        - cvxpy.cvxcore.python
+        - cvxpy.constraints
+        - cvxpy.expressions
+        - cvxpy.expressions.constants
+        - cvxpy.interface
+        - cvxpy.interface.numpy_interface
+        - cvxpy.lin_ops
+        - cvxpy.problems
+        - cvxpy.reductions
+        - cvxpy.reductions.complex2real
+        - cvxpy.reductions.complex2real.atom_canonicalizers
+        - cvxpy.reductions.dcp2cone
+        - cvxpy.reductions.dcp2cone.atom_canonicalizers
+        - cvxpy.reductions.eliminate_pwl
+        - cvxpy.reductions.eliminate_pwl.atom_canonicalizers
+        - cvxpy.reductions.qp2quad_form
+        - cvxpy.reductions.qp2quad_form.atom_canonicalizers
+        - cvxpy.reductions.eliminate_pwl.atom_canonicalizers
+        - cvxpy.reductions.solvers
+        - cvxpy.reductions.solvers.conic_solvers
+        - cvxpy.reductions.solvers.qp_solvers
+        - cvxpy.reductions.solvers.lp_solvers
+        - cvxpy.tests
+        - cvxpy.transforms
+        - cvxpy.utilities
         - cvxpy.cvxcore.python
 
 about:


### PR DESCRIPTION
Upstream cvxpy has a conda-recipe as well, and since (more or less) recently, this is running the test-suite as part of the build, see https://github.com/cvxgrp/cvxpy/commit/eff752f1d1151017a1cbe1a8c8a0abb12ebaa855

~I brought up the possibility of running test suite [before](https://github.com/conda-forge/cvxpy-feedstock/pull/36#issuecomment-637772911), but didn't receive an answer. Now I'm just going ahead and seeing what comes out (also slightly motivated by seeing cvxgrp/cvxpy#1003). Fingers crossed~

Nevermind, it's been running in this recipe for a while [already](https://github.com/conda-forge/cvxpy-feedstock/blame/master/recipe/meta.yaml#L48); this means this PR just syncs the import tests.