### PR TITLE
Manual pypy37 migration

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -24,6 +24,10 @@ jobs:
         CONFIG: linux_64_numpy1.18python3.6.____73_pypy
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_numpy1.19python3.7.____73_pypy:
+        CONFIG: linux_64_numpy1.19python3.7.____73_pypy
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
       linux_64_numpy1.19python3.9.____cpython:
         CONFIG: linux_64_numpy1.19python3.9.____cpython
         UPLOAD_PACKAGES: 'True'

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -20,6 +20,9 @@ jobs:
       osx_64_numpy1.18python3.6.____73_pypy:
         CONFIG: osx_64_numpy1.18python3.6.____73_pypy
         UPLOAD_PACKAGES: 'True'
+      osx_64_numpy1.19python3.7.____73_pypy:
+        CONFIG: osx_64_numpy1.19python3.7.____73_pypy
+        UPLOAD_PACKAGES: 'True'
       osx_64_numpy1.19python3.9.____cpython:
         CONFIG: osx_64_numpy1.19python3.9.____cpython
         UPLOAD_PACKAGES: 'True'

--- a/.ci_support/linux_64_numpy1.19python3.7.____73_pypy.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.7.____73_pypy.yaml
@@ -1,0 +1,33 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
+numpy:
+- '1.19'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_73_pypy
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - cdt_name
+  - docker_image
+- - python
+  - numpy

--- a/.ci_support/linux_aarch64_numpy1.19python3.7.____73_pypy.yaml
+++ b/.ci_support/linux_aarch64_numpy1.19python3.7.____73_pypy.yaml
@@ -1,0 +1,35 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+numpy:
+- '1.19'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_73_pypy
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/migrations/pypy37.yaml
+++ b/.ci_support/migrations/pypy37.yaml
@@ -1,0 +1,30 @@
+migrator_ts: 1608144114
+__migrator:
+    migration_number: 1
+    operation: key_add
+    primary_key: python
+    ordering:
+        python:
+            - 3.6.* *_cpython
+            - 3.7.* *_cpython
+            - 3.8.* *_cpython
+            - 3.9.* *_cpython
+            - 3.6.* *_73_pypy
+            - 3.7.* *_73_pypy  # new entry
+    paused: False
+    longterm: True
+    pr_limit: 10
+    bump_number: 0
+    exclude:
+      # this shouldn't attempt to modify the python feedstocks
+      - python
+      - pypy3.6
+      - pypy-meta
+
+python:                # [not (win or arm64)]
+  - 3.7.* *_73_pypy    # [not (win or arm64)]
+# additional entries to add for zip_keys
+numpy:                 # [not (win or arm64)]
+  - 1.19               # [not (win or arm64)]
+python_impl:           # [not (win or arm64)]
+  - pypy               # [not (win or arm64)]

--- a/.ci_support/osx_64_numpy1.19python3.7.____73_pypy.yaml
+++ b/.ci_support/osx_64_numpy1.19python3.7.____73_pypy.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '1.19'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_73_pypy
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.drone.yml
+++ b/.drone.yml
@@ -124,6 +124,37 @@ steps:
 
 ---
 kind: pipeline
+name: linux_aarch64_numpy1.19python3.7.____73_pypy
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Install and build
+  image: quay.io/condaforge/linux-anvil-aarch64
+  environment:
+    CONFIG: linux_aarch64_numpy1.19python3.7.____73_pypy
+    UPLOAD_PACKAGES: True
+    PLATFORM: linux-aarch64
+    BINSTAR_TOKEN:
+      from_secret: BINSTAR_TOKEN
+    FEEDSTOCK_TOKEN:
+      from_secret: FEEDSTOCK_TOKEN
+    STAGING_BINSTAR_TOKEN:
+      from_secret: STAGING_BINSTAR_TOKEN
+  commands:
+    - export FEEDSTOCK_ROOT="$DRONE_WORKSPACE"
+    - export RECIPE_ROOT="$FEEDSTOCK_ROOT/recipe"
+    - export CI=drone
+    - export GIT_BRANCH="$DRONE_BRANCH"
+    - export FEEDSTOCK_NAME=$(basename ${DRONE_REPO_NAME})
+    - sed -i '$ichown -R conda:conda "$FEEDSTOCK_ROOT"' /opt/docker/bin/entrypoint
+    - /opt/docker/bin/entrypoint $FEEDSTOCK_ROOT/.scripts/build_steps.sh
+    - echo "Done building"
+
+---
+kind: pipeline
 name: linux_aarch64_numpy1.19python3.9.____cpython
 
 platform:

--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_64_numpy1.19python3.7.____73_pypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=205&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cvxpy-feedstock?branchName=master&jobName=linux&configuration=linux_64_numpy1.19python3.7.____73_pypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_64_numpy1.19python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=205&branchName=master">
@@ -107,6 +114,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_aarch64_numpy1.19python3.7.____73_pypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=205&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cvxpy-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_numpy1.19python3.7.____73_pypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_aarch64_numpy1.19python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=205&branchName=master">
@@ -139,6 +153,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=205&branchName=master">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cvxpy-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.18python3.6.____73_pypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_numpy1.19python3.7.____73_pypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=205&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cvxpy-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.19python3.7.____73_pypy" alt="variant">
                 </a>
               </td>
             </tr><tr>


### PR DESCRIPTION
The migrator closed #45 prematurely, and seems to be rerunning into an [error](https://conda-forge.org/status/) while retrying:

<details>

```
6. cvxpy (5) Error: not solvable: master:
linux_64_numpy1.19python3.7.____73_pypy: Encountered problems while solving.
Problem: package osqp-0.6.1-py36h830a2c2_2 requires python_abi 3.6.* *_cp36m, but none of the providers can be installed
Problem: package scs-2.0.2-py37ha7ef4f4_0 requires python >=3.7,<3.8.0a0, but none of the providers can be installed
linux_aarch64_numpy1.19python3.7.____73_pypy: Encountered problems while solving.
Problem: package osqp-0.6.1-py36h7c3b610_2 requires python_abi 3.6.* *_cp36m, but none of the providers can be installed
Problem: nothing provides openssl >=1.0.2p,<1.0.3a needed by python-3.6.7-hd21baee_1002
osx_64_numpy1.19python3.7.____73_pypy: Encountered problems while solving.
Problem: package osqp-0.6.1-py36hcc1bba6_2 requires python_abi 3.6.* *_cp36m, but none of the providers can be installed
Problem: package scs-2.0.2-py37ha7ef4f4_0 requires python >=3.7,<3.8.0a0, but none of the providers can be installed

```

</details>

Now that https://github.com/conda-forge/scipy-feedstock/pull/155, https://github.com/conda-forge/qdldl-python-feedstock/pull/10 & https://github.com/conda-forge/osqp-feedstock/pull/33 are merged, give this another shot...