### PR TITLE
bump numpy

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -71,8 +71,9 @@ outputs:
       run:
         - python
         - ${{ pin_subpackage('cvxpy-base', exact=True) }}
+        # default run-export of numpy is too loose (>=1.23,<3); cvxpy really needs >=2
         - numpy >=2
-        - highspy >=1.11.0
+        - highspy >=1.11.0,!=1.14.0
         - osqp >=1.0.0
         - clarabel >=0.5
         - scs >=3.2.4

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ source:
       - patches/0001-loosen-time-limit-in-test_scipy_mi_time_limit_reache.patch
 
 build:
-  number: 0
+  number: 1
   skip:
     - match(python, "<3.11")
 
@@ -71,6 +71,7 @@ outputs:
       run:
         - python
         - ${{ pin_subpackage('cvxpy-base', exact=True) }}
+        - numpy >=2
         - highspy >=1.11.0
         - osqp >=1.0.0
         - clarabel >=0.5


### PR DESCRIPTION
`conda create -n test -c conda-forge "cvxpy>=1.8" "numpy<2"` incorrectly installs a broken environment instead of failing due to version incompatibilities.

#121 was missing a `numpy>=2` run constraint (vis. <https://github.com/cvxpy/cvxpy/blob/v1.8.2/pyproject.toml>).